### PR TITLE
ES module version

### DIFF
--- a/esm.js
+++ b/esm.js
@@ -1,0 +1,57 @@
+export default function stringify(data, opts) {
+    if (!opts) opts = {};
+    if (typeof opts === 'function') opts = { cmp: opts };
+    const cycles = (typeof opts.cycles === 'boolean') ? opts.cycles : false;
+
+    const cmp = opts.cmp && (function (f) {
+        return function (node) {
+            return function (a, b) {
+                const aobj = { key: a, value: node[a] };
+                const bobj = { key: b, value: node[b] };
+                return f(aobj, bobj);
+            };
+        };
+    })(opts.cmp);
+
+    const seen = [];
+    return (function stringifyNode(node) {
+        if (node && node.toJSON && typeof node.toJSON === 'function') {
+            node = node.toJSON();
+        }
+
+        if (node === undefined) return;
+        if (typeof node == 'number') return isFinite(node) ? '' + node : 'null';
+        if (typeof node !== 'object') return JSON.stringify(node);
+
+        let i, out;
+        if (Array.isArray(node)) {
+            out = '[';
+            for (i = 0; i < node.length; i++) {
+                if (i) out += ',';
+                out += stringifyNode(node[i]) || 'null';
+            }
+            return out + ']';
+        }
+
+        if (node === null) return 'null';
+
+        if (seen.indexOf(node) !== -1) {
+            if (cycles) return JSON.stringify('__cycle__');
+            throw new TypeError('Converting circular structure to JSON');
+        }
+
+        const seenIndex = seen.push(node) - 1;
+        const keys = Object.keys(node).sort(cmp && cmp(node));
+        out = '';
+        for (i = 0; i < keys.length; i++) {
+            const key = keys[i];
+            const value = stringifyNode(node[key]);
+
+            if (!value) continue;
+            if (out) out += ',';
+            out += JSON.stringify(key) + ':' + value;
+        }
+        seen.splice(seenIndex, 1);
+        return '{' + out + '}';
+    })(data);
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0",
   "description": "deterministic `JSON.stringify()` - a faster version of substack's json-stable-strigify without jsonify",
   "main": "index.js",
+  "module": "esm.js",
   "types": "index.d.ts",
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
I need an ES module version of this package for a project. I simply created an esm.js copy of the CommonJS version.

I'm a bit unsure on how to setup a testing and linting so that both versions can co-exist without changeing the project structure too much, I'm all up for working on that if it sounds like a good idea if I can get some hints on which project structure you would like.