### PR TITLE
Use npm files to reduce the package content

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     "test-spec": "tape test/*.js",
     "test": "npm run eslint && nyc npm run test-spec"
   },
+  "files": [
+    "index.d.ts",
+    "index.js"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/epoberezkin/fast-json-stable-stringify.git"


### PR DESCRIPTION
At npm we just need the `index.js` and the `index.d.ts` files, so:

<img width="315" alt="Screenshot 2020-06-07 at 18 43 32" src="https://user-images.githubusercontent.com/1007051/83974613-f25bb280-a8ee-11ea-993a-baedff2b2b14.png">
