### PR TITLE
Add native Node.js ES Modules support

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -2,6 +2,9 @@ extends: eslint:recommended
 env:
   node: true
   browser: true
+parserOptions:
+  sourceType: "module"
+  ecmaVersion: 2015
 rules:
   block-scoped-var: 2
   callback-return: 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules
 .nyc_output/
 coverage/
-.DS_Store
+dist/
+node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "8"
   - "10"
   - "12"
   - "13"

--- a/index.js
+++ b/index.js
@@ -1,6 +1,4 @@
-'use strict';
-
-module.exports = function (data, opts) {
+export default function (data, opts) {
     if (!opts) opts = {};
     if (typeof opts === 'function') opts = { cmp: opts };
     var cycles = (typeof opts.cycles === 'boolean') ? opts.cycles : false;
@@ -56,4 +54,4 @@ module.exports = function (data, opts) {
         seen.splice(seenIndex, 1);
         return '{' + out + '}';
     })(data);
-};
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,13 @@
   "name": "fast-json-stable-stringify",
   "version": "2.1.0",
   "description": "deterministic `JSON.stringify()` - a faster version of substack's json-stable-strigify without jsonify",
-  "main": "index.js",
+  "main": "./dist/cjs/index.js",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/es/index.js"
+  },
+  "module": "./dist/es/index.js",
+  "type": "commonjs",
   "types": "index.d.ts",
   "dependencies": {},
   "devDependencies": {
@@ -14,13 +20,21 @@
     "json-stable-stringify": "latest",
     "nyc": "^14.1.0",
     "pre-commit": "^1.2.2",
+    "rollup": "^2.14.0",
     "tape": "^4.11.0"
   },
   "scripts": {
-    "eslint": "eslint index.js test",
-    "test-spec": "tape test/*.js",
-    "test": "npm run eslint && nyc npm run test-spec"
+    "build": "rollup --config",
+    "lint": "eslint index.js test/",
+    "prepare": "npm run build",
+    "prepublishOnly": "npm run lint && npm test",
+    "test-spec": "npm run build && tape test/*.js",
+    "test": "npm run lint && nyc npm run test-spec"
   },
+  "files": [
+    "dist/",
+    "index.d.ts"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/epoberezkin/fast-json-stable-stringify.git"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,22 @@
+import pkg from './package.json';
+
+function emitModulePackageFile() {
+    return {
+        name: 'emit-module-package-file',
+        generateBundle() {
+            this.emitFile({
+                type: 'asset',
+                fileName: 'package.json',
+                source: '{"type":"module"}'
+            });
+        }
+    };
+}
+
+export default {
+    input: 'index.js',
+    output: [
+        { file: pkg.main, format: 'cjs' },
+        { file: pkg.module, format: 'es', plugins: [emitModulePackageFile()] }
+    ]
+};

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -1,0 +1,2 @@
+parserOptions:
+  sourceType: "script"


### PR DESCRIPTION
In this PR I add **native Node.js ES Modules support**.

Following the same recommendations as the Rollup plugins:
- https://github.com/rollup/plugins/pull/413
- https://github.com/rollup/plugins/pull/419

Fix #8.