### PR TITLE
[README] fix typo in upstream package name, add link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fast-json-stable-stringify
 
-Deterministic `JSON.stringify()` - a faster version of [@substack](https://github.com/substack)'s json-stable-strigify without [jsonify](https://github.com/substack/jsonify).
+Deterministic `JSON.stringify()` - a faster version of [@substack](https://github.com/substack)'s [json-stable-stringify](https://github.com/substack/json-stable-stringify) without [jsonify](https://github.com/substack/jsonify).
 
 You can also pass in a custom comparison function.
 


### PR DESCRIPTION
* Correct typo "json-stable-strigify" -> "json-stable-stringify"

* Add link to json-stable-stringify repo