### PR TITLE
docs: fix strigify -> stringify typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fast-json-stable-stringify
 
-Deterministic `JSON.stringify()` - a faster version of [@substack](https://github.com/substack)'s json-stable-strigify without [jsonify](https://github.com/substack/jsonify).
+Deterministic `JSON.stringify()` - a faster version of [@substack](https://github.com/substack)'s json-stable-stringify without [jsonify](https://github.com/substack/jsonify).
 
 You can also pass in a custom comparison function.
 


### PR DESCRIPTION
Just something I noticed while reading the README. 

Nice library. I'm about to use it in a project. Thanks!
